### PR TITLE
Various Gene Updates

### DIFF
--- a/js/fr_data.js
+++ b/js/fr_data.js
@@ -44,6 +44,7 @@ FRData.ModernPrimaryGeneList = [
     ['Boulder', 'Limited', ''],
     ['Ground', 'Limited', ''],
     ['Tide', 'Limited', ''],
+    ['Fern', 'Limited', ''],
     ['Pinstripe', 'Limited', '100000 T (Baldwin)'],
     ['Poison', 'Limited', '100000 T (Baldwin)'],
     ['Skink', 'Limited', '95000 T (Baldwin)'],
@@ -90,6 +91,7 @@ FRData.ModernSecondaryGeneList = [
     ['Fissure', 'Limited', ''],
     ['Myrid', 'Limited', ''],
     ['Foam', 'Limited', ''],
+    ['Paisley', 'Limited', ''],
     ['Patchwork', 'Limited', '100000 T (Baldwin)'],
     ['Sludge', 'Limited', '90000 T (Baldwin)'],
     ['Spinner', 'Limited', '95000 T (Baldwin)'],
@@ -245,6 +247,7 @@ FRData.BanescalePrimaryGeneList = [
     ['Ragged', 'Uncommon', '100000 T'],
     ['Ripple', 'Uncommon', ''],
 
+    ['Fern', 'Limited', ''],
     ['Candycane', 'Limited', 'The Coliseum'],
     ['Pinstripe', 'Limited', '50000 T (Baldwin)'],
     ['Poison', 'Limited', '50000 T (Baldwin)'],
@@ -274,6 +277,7 @@ FRData.BanescaleSecondaryGeneList = [
     ['Seraph', 'Uncommon', '49000 T'],
     ['Tear', 'Uncommon', '80000 T'],
 
+    ['Paisley', 'Limited', ''],
     ['Spinner', 'Limited', '47500 T (Baldwin)'],
     ['Sugarplum', 'Limited', 'The Coliseum'],
     ['Toxin', 'Limited', '50000 T (Baldwin)'],
@@ -329,6 +333,7 @@ FRData.VeilspunPrimaryGeneList = [
     ['Vipera', 'Uncommon', ''],
 
     ['Skink', 'Limited', ''],
+    ['Fern', 'Limited', ''],
 
     ['Starmap', 'Rare', ''],
     ['Stitched', 'Rare', ''],
@@ -353,6 +358,7 @@ FRData.VeilspunSecondaryGeneList = [
 
     ['Patchwork', 'Limited', ''],
     ['Spinner', 'Limited', ''],
+    ['Paisley', 'Limited', ''],
 
     ['Bee', 'Rare', ''],
     ['Constellation', 'Rare', '']

--- a/js/fr_data.js
+++ b/js/fr_data.js
@@ -43,8 +43,7 @@ FRData.ModernPrimaryGeneList = [
 
     ['Boulder', 'Limited', ''],
     ['Ground', 'Limited', ''],
-    ['Tide', 'Limited', ''],
-    ['Fern', 'Limited', ''],
+    ['Fern-Gene', 'Limited', ''],
     ['Pinstripe', 'Limited', '100000 T (Baldwin)'],
     ['Poison', 'Limited', '100000 T (Baldwin)'],
     ['Skink', 'Limited', '95000 T (Baldwin)'],
@@ -90,7 +89,6 @@ FRData.ModernSecondaryGeneList = [
 
     ['Fissure', 'Limited', ''],
     ['Myrid', 'Limited', ''],
-    ['Foam', 'Limited', ''],
     ['Paisley', 'Limited', ''],
     ['Patchwork', 'Limited', '100000 T (Baldwin)'],
     ['Sludge', 'Limited', '90000 T (Baldwin)'],
@@ -237,6 +235,7 @@ FRData.BanescalePrimaryGeneList = [
     ['Leopard', 'Common', ''],
     ['Marble', 'Common', '90000 T'],
     ['Savannah', 'Common', '70000 T'],
+    ['Speckle', 'Common', '62500 T'],
     ['Tapir', 'Common', ''],
     ['Tiger', 'Common', '67500 T'],
 
@@ -247,7 +246,7 @@ FRData.BanescalePrimaryGeneList = [
     ['Ragged', 'Uncommon', '100000 T'],
     ['Ripple', 'Uncommon', ''],
 
-    ['Fern', 'Limited', ''],
+    ['Fern-Gene', 'Limited', ''],
     ['Candycane', 'Limited', 'The Coliseum'],
     ['Pinstripe', 'Limited', '50000 T (Baldwin)'],
     ['Poison', 'Limited', '50000 T (Baldwin)'],
@@ -265,6 +264,7 @@ FRData.BanescaleSecondaryGeneList = [
     ['Current', 'Common', ''],
     ['Edged', 'Common', '60000 T'],
     ['EyeSpots', 'Common', ''],
+    ['Freckle', 'Common', '45000 T'],
     ['Mottle', 'Common', '60000 T'],
     ['Peregrine', 'Common', ''],
     ['Safari', 'Common', '49000 T'],
@@ -296,7 +296,8 @@ FRData.BanescaleTertiaryGeneList = [
 
     ['Crackle', 'Uncommon', '95000 T'],
     ['Ghost', 'Uncommon', '80000 T'],
-    ['Lace', 'Uncommon', '77500 T'],    
+    ['Lace', 'Uncommon', '77500 T'],
+    ['Peacock-Gene', 'Common', '75000 T'],
     ['Ringlets', 'Uncommon', '77500 T'],
     ['Sparkle', 'Uncommon', ''],
 
@@ -312,8 +313,6 @@ FRData.BanescaleTertiaryGeneList = [
     ['Plumage', 'Rare', '500 G'],
     ['Stained', 'Rare', ''],
     ['Wraith', 'Rare', '500 G']
-
-    
 ]
 
 FRData.VeilspunPrimaryGeneList = [
@@ -333,7 +332,7 @@ FRData.VeilspunPrimaryGeneList = [
     ['Vipera', 'Uncommon', ''],
 
     ['Skink', 'Limited', ''],
-    ['Fern', 'Limited', ''],
+    ['Fern-Gene', 'Limited', ''],
 
     ['Starmap', 'Rare', ''],
     ['Stitched', 'Rare', ''],
@@ -422,7 +421,7 @@ FRData.AberrationSecondaryGeneList = [
     ['Basic', 'Plentiful', '10000 T'],
 
     ['Blend', 'Common', ''],
-    ['Freckled', 'Common', ''],
+    ['Freckle', 'Common', ''],
     ['Marbled', 'Common', ''],
     ['Peregrine', 'Common', ''],
     ['Safari', 'Common', ''],

--- a/js/fr_data.js
+++ b/js/fr_data.js
@@ -43,6 +43,7 @@ FRData.ModernPrimaryGeneList = [
 
     ['Boulder', 'Limited', ''],
     ['Ground', 'Limited', ''],
+    ['Tide', 'Limited', ''],
     ['Pinstripe', 'Limited', '100000 T (Baldwin)'],
     ['Poison', 'Limited', '100000 T (Baldwin)'],
     ['Skink', 'Limited', '95000 T (Baldwin)'],
@@ -88,6 +89,7 @@ FRData.ModernSecondaryGeneList = [
 
     ['Fissure', 'Limited', ''],
     ['Myrid', 'Limited', ''],
+    ['Foam', 'Limited', ''],
     ['Patchwork', 'Limited', '100000 T (Baldwin)'],
     ['Sludge', 'Limited', '90000 T (Baldwin)'],
     ['Spinner', 'Limited', '95000 T (Baldwin)'],
@@ -445,6 +447,7 @@ FRData.AberrationTertiaryGeneList = [
     ['Kumo', 'Common', ''],
     ['Peacock-Gene', 'Common', ''],
     ['Thylacine', 'Common', ''],
+    ['Underbelly', 'Common', '75000 T'],
 
     ['Fangs', 'Uncommon', ''],
     ['Flecks', 'Uncommon', ''],

--- a/js/fr_data.js
+++ b/js/fr_data.js
@@ -320,10 +320,14 @@ FRData.VeilspunPrimaryGeneList = [
 
     ['Clown', 'Common', ''],
     ['Fade', 'Common', ''],
+    ['Falcon', 'Common', '85000 T'],
     ['Laced', 'Common', ''],
+    ['Leopard', 'Common', '70000 T'],
+    ['Speckle', 'Common', '62500 T'],
     ['Tapir', 'Common', ''],
 
     ['Arc', 'Uncommon', ''],
+    ['Bar', 'Uncommon', '125000 T'],
     ['Bright', 'Uncommon', ''],
     ['Giraffe', 'Uncommon', ''],
     ['Jupiter', 'Uncommon', ''],
@@ -331,9 +335,14 @@ FRData.VeilspunPrimaryGeneList = [
     ['Sphinxmoth', 'Uncommon', ''],
     ['Vipera', 'Uncommon', ''],
 
-    ['Skink', 'Limited', ''],
     ['Fern-Gene', 'Limited', ''],
+    ['Poison', 'Limited', '50000 T (Baldwin)'],
+    ['Skink', 'Limited', ''],
+    ['Slime', 'Limited', '50000 T (Baldwin)'],
+    ['Veined', 'Limited', '50000 T (Baldwin)'],
 
+    ['Crystal', 'Rare', '750 G'],
+    ['Petals', 'Rare', '750 G'],
     ['Starmap', 'Rare', ''],
     ['Stitched', 'Rare', ''],
     ['Wasp', 'Rare', '']
@@ -343,10 +352,14 @@ FRData.VeilspunSecondaryGeneList = [
     ['Basic', 'Plentiful', '10000 T'],
 
     ['Blend', 'Common', ''],
+    ['Clouded', 'Common', '60000 T'],
     ['Edged', 'Common', ''],
     ['EyeSpots', 'Common', ''],
+    ['Freckle', 'Common', '45000 T'],
+    ['Peregrine', 'Common', '70000 T'],
     ['Striation', 'Common', ''],
 
+    ['Daub', 'Uncommon', '82500 T'],
     ['Hawkmoth', 'Uncommon', ''],
     ['Hex', 'Uncommon', ''],
     ['Hypnotic', 'Uncommon', ''],
@@ -355,12 +368,16 @@ FRData.VeilspunSecondaryGeneList = [
     ['Vivid', 'Uncommon', ''],
     ['Web', 'Uncommon', ''],
 
+    ['Paisley', 'Limited', ''],
     ['Patchwork', 'Limited', ''],
     ['Spinner', 'Limited', ''],
-    ['Paisley', 'Limited', ''],
+    ['Sludge', 'Limited', '45000 T (Baldwin)'],
+    ['Toxin', 'Limited', '50000 T (Baldwin)'],
 
     ['Bee', 'Rare', ''],
-    ['Constellation', 'Rare', '']
+    ['Butterfly', 'Rare', '600 G'],
+    ['Constellation', 'Rare', ''],
+    ['Facet', 'Rare', '600 G']
 ]
 
 FRData.VeilspunTertiaryGeneList = [
@@ -371,8 +388,10 @@ FRData.VeilspunTertiaryGeneList = [
 
     ['Crackle', 'Uncommon', ''],
     ['Flecks', 'Uncommon', ''],
+    ['Ghost', 'Uncommon', '80000 T'],
     ['Okapi', 'Uncommon', ''],
     ['Runes', 'Uncommon', ''],
+    ['Sparkle', 'Uncommon', '75000 T'],
     ['Thorns', 'Uncommon', ''],
 
     ['Angler', 'Limited', ''],
@@ -382,7 +401,9 @@ FRData.VeilspunTertiaryGeneList = [
     ['Firefly', 'Limited', ''],
 
     ['Diaphanous', 'Rare', ''],
+    ['Filigree', 'Rare', '500 G'],
     ['Glimmer', 'Rare', ''],
+    ['Koi', 'Rare', '500 G'],
     ['Mop', 'Rare', ''],
     ['Opal', 'Rare', ''],
     ['Stained', 'Rare', '']

--- a/js/fr_data.js
+++ b/js/fr_data.js
@@ -406,7 +406,7 @@ FRData.AberrationPrimaryGeneList = [
     ['Stitched', 'Limited', ''],
 
     ['Crystal', 'Rare', ''],
-    ['Pharoh', 'Rare', ''],
+    ['Pharaoh', 'Rare', ''],
     ['Wasp', 'Rare', '']
 ]
 

--- a/lg/basic-en.json
+++ b/lg/basic-en.json
@@ -380,10 +380,11 @@
     "Rose": "Rose",
     "Pearl": "Pearl",
 
-"Ground":"Ground",
-"Fissure":"Fissure",
-"Sarcophagus":"Sarcophagus",
-"Pinions":"Pinions",
-"Gliders":"Gliders",
-"Angler":"Angler"
+    "Ground":"Ground",
+    "Fissure":"Fissure",
+    "Pharaoh": "Pharaoh",
+    "Sarcophagus":"Sarcophagus",
+    "Pinions":"Pinions",
+    "Gliders":"Gliders",
+    "Angler":"Angler"
 }

--- a/lg/basic-en.json
+++ b/lg/basic-en.json
@@ -386,5 +386,7 @@
     "Sarcophagus":"Sarcophagus",
     "Pinions":"Pinions",
     "Gliders":"Gliders",
-    "Angler":"Angler"
+    "Angler":"Angler",
+    "Tide":"Tide",
+    "Foam":"Foam"
 }

--- a/lg/basic-en.json
+++ b/lg/basic-en.json
@@ -380,13 +380,14 @@
     "Rose": "Rose",
     "Pearl": "Pearl",
 
-    "Ground":"Ground",
-    "Fissure":"Fissure",
+    "Ground": "Ground",
+    "Fissure": "Fissure",
     "Pharaoh": "Pharaoh",
-    "Sarcophagus":"Sarcophagus",
-    "Pinions":"Pinions",
-    "Gliders":"Gliders",
-    "Angler":"Angler",
-    "Tide":"Tide",
-    "Foam":"Foam"
+    "Sarcophagus": "Sarcophagus",
+    "Pinions": "Pinions",
+    "Gliders": "Gliders",
+    "Angler": "Angler",
+    "Tide": "Tide",
+    "Foam": "Foam",
+    "Paisley": "Paisley"
 }

--- a/lg/basic-en.json
+++ b/lg/basic-en.json
@@ -387,7 +387,6 @@
     "Pinions": "Pinions",
     "Gliders": "Gliders",
     "Angler": "Angler",
-    "Tide": "Tide",
-    "Foam": "Foam",
+    "Fern-Gene": "Fern",
     "Paisley": "Paisley"
 }

--- a/lg/basic-en.json
+++ b/lg/basic-en.json
@@ -388,5 +388,6 @@
     "Gliders": "Gliders",
     "Angler": "Angler",
     "Fern-Gene": "Fern",
-    "Paisley": "Paisley"
+    "Paisley": "Paisley",
+    "Koi": "Koi"
 }

--- a/lg/basic-zh.json
+++ b/lg/basic-zh.json
@@ -380,10 +380,11 @@
     "Rose": "玫瑰色 Rose",
     "Pearl": "珍珠色 Pearl",
 
-"Ground":"Ground",
-"Fissure":"Fissure",
-"Sarcophagus":"Sarcophagus",
-"Pinions":"Pinions",
-"Gliders":"Gliders",
-"Angler":"Angler"
+    "Ground":"Ground",
+    "Fissure":"Fissure",
+    "Pharaoh": "Pharaoh",
+    "Sarcophagus":"Sarcophagus",
+    "Pinions":"Pinions",
+    "Gliders":"Gliders",
+    "Angler":"Angler"
 }

--- a/lg/basic-zh.json
+++ b/lg/basic-zh.json
@@ -386,5 +386,7 @@
     "Sarcophagus":"Sarcophagus",
     "Pinions":"Pinions",
     "Gliders":"Gliders",
-    "Angler":"Angler"
+    "Angler":"Angler",
+    "Tide":"Tide",
+    "Foam":"Foam"
 }

--- a/lg/basic-zh.json
+++ b/lg/basic-zh.json
@@ -380,13 +380,14 @@
     "Rose": "玫瑰色 Rose",
     "Pearl": "珍珠色 Pearl",
 
-    "Ground":"Ground",
-    "Fissure":"Fissure",
+    "Ground": "Ground",
+    "Fissure": "Fissure",
     "Pharaoh": "Pharaoh",
-    "Sarcophagus":"Sarcophagus",
-    "Pinions":"Pinions",
-    "Gliders":"Gliders",
-    "Angler":"Angler",
-    "Tide":"Tide",
-    "Foam":"Foam"
+    "Sarcophagus": "Sarcophagus",
+    "Pinions": "Pinions",
+    "Gliders": "Gliders",
+    "Angler": "Angler",
+    "Tide": "Tide",
+    "Foam": "Foam",
+    "Paisley": "Paisley"
 }

--- a/lg/basic-zh.json
+++ b/lg/basic-zh.json
@@ -387,7 +387,6 @@
     "Pinions": "Pinions",
     "Gliders": "Gliders",
     "Angler": "Angler",
-    "Tide": "Tide",
-    "Foam": "Foam",
+    "Fern-Gene": "Fern",
     "Paisley": "Paisley"
 }

--- a/lg/basic-zh.json
+++ b/lg/basic-zh.json
@@ -388,5 +388,6 @@
     "Gliders": "Gliders",
     "Angler": "Angler",
     "Fern-Gene": "Fern",
-    "Paisley": "Paisley"
+    "Paisley": "Paisley",
+    "Koi": "Koi"
 }


### PR DESCRIPTION
@JiYouMCC 

What this includes:
- Renamed `Pharoh` to `Pharaoh`
- Added Underbelly to those missing it
- Added Fern and Paisley
- Added missing Banescale genes
- Added missing Veilspun genes
- Renamed a `Freckled` to `Freckle`
- Updated the language files where I could - I added the new stuff to the bottom

I decided not to include:
- Tide and Foam. I see another pull request implemented it